### PR TITLE
🐛 fix(requirements): 修正 pydantic-validation-decorator 的包名为 pydantic_v…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,11 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+

--- a/ruoyi-fastapi-backend/module_generator/service/gen_service.py
+++ b/ruoyi-fastapi-backend/module_generator/service/gen_service.py
@@ -347,9 +347,9 @@ class GenTableService:
         """
         gen_path = gen_table.gen_path
         if gen_path == '/':
-            return os.path.join(os.getcwd(), GenConfig.GEN_PATH, TemplateUtils.get_file_name(template, gen_table))
+            return os.path.join(os.getcwd(), GenConfig.GEN_PATH, TemplateUtils.get_file_name([template], gen_table))
         else:
-            return os.path.join(gen_path, TemplateUtils.get_file_name(template, gen_table))
+            return os.path.join(gen_path, TemplateUtils.get_file_name([template], gen_table))
 
     @classmethod
     async def sync_db_services(cls, query_db: AsyncSession, table_name: str):

--- a/ruoyi-fastapi-backend/requirements.txt
+++ b/ruoyi-fastapi-backend/requirements.txt
@@ -8,7 +8,7 @@ pandas==2.2.3
 passlib[bcrypt]==1.7.4
 Pillow==11.1.0
 psutil==7.0.0
-pydantic-validation-decorator==0.1.4
+pydantic_validation_decorator==0.1.4
 PyJWT[crypto]==2.10.1
 PyMySQL==1.1.1
 redis==5.2.1


### PR DESCRIPTION
一些小问题

🐛 fix(requirements): 修正 pydantic-validation-decorator 的包名为 pydantic_validation_decorator
pycharm始终提示该包未安装
确切来说这个包自身的问题，pypi上的名称和实际安装后的包名不一致，减号改成下划线即可

♻️ refactor(gen_service.py): 优化模板文件名获取逻辑，处理模板列表
方法接受一个List[str]，但是传入的是一个str

🗑️ chore(.gitignore): 添加对 PyCharm 的忽略规则，排除 .idea 目录

